### PR TITLE
Postgresql Docker setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker/dockerdata/

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,4 @@
+POSTGRES_USER=localuser
+POSTGRES_DB=localdev
+PGADMIN_DEFAULT_EMAIL=local@invalid.com
+PGADMIN_DEFAULT_PASSWORD=pgadmin

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,44 @@
+# Command to run docker-compose up
+
+version: '3'
+services:
+  # This will download Postgres and set following properties
+  # hostname: postgres
+  # username is passed in command
+  # password is blank
+  # and will create database with name 'localdb'
+  # hostname will be used while connecting postgres from postgres admin
+  # for persisting data it will create folder 'pgdata' in present working directory
+  # for creating database and tables it will copy '00_init.sql' to docker container and will run those scripts at the time of creating docker container
+  postgres:
+    container_name: postgres
+    image: postgres:10.8 
+    hostname: postgres
+    environment:
+    # pick from file name
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_DB=${POSTGRES_DB}
+    ports:
+      - '5432:5432'
+    volumes:
+      - ./dockerdata/pgdata:/var/lib/postgresql/data
+      # Uncomment the below line if you have data to be restored or want to run sql commands at initalization.
+      - ../.local/00_init.sql:/docker-entrypoint-initdb.d/00_init.sql
+     
+
+  # This will download pgAdmin and set following properties
+  # email is passed in command
+  # password is passed in command
+  # for persisting data it will create folder 'pgadmindata' in present working directory
+  pgAdmin:
+    container_name: pgAdmin
+    image: dpage/pgadmin4
+    depends_on:
+      - postgres
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=${PGADMIN_DEFAULT_EMAIL}
+      - PGADMIN_DEFAULT_PASSWORD=${PGADMIN_DEFAULT_PASSWORD}
+    ports:
+      - '9080:80'
+    volumes:
+      - ./dockerdata/pgadmindata:/var/lib/pgadmin

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - ./dockerdata/pgdata:/var/lib/postgresql/data
       # Uncomment the below line if you have data to be restored or want to run sql commands at initalization.
-      - ../.local/00_init.sql:/docker-entrypoint-initdb.d/00_init.sql
+      #- ../.local/00_init.sql:/docker-entrypoint-initdb.d/00_init.sql
      
 
   # This will download pgAdmin and set following properties


### PR DESCRIPTION
Postgresql Docker setup

.env is picked up by default when we run "docker-compose  up"

dockerdata folder is added to git ignore so that no one commits there postgresql data and also this folder stores postgresql data and data is not lost when docker is stopped.
