### PR TITLE
[Issue #17] Fix for Unable to start the npm start after cloning the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ We engage with Contributors on FindCollabs - https://findcollabs.com/project/OVx
 ```
 cd spent-react-ui
 npm start
+npm install
 ```


### PR DESCRIPTION
Fix for Unable to start the npm start after cloning the project